### PR TITLE
Add missing submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "deep2-client"]
 	path = deep2-client
 	url = https://github.com/OPSILab/deep2-client
+[submodule "wait-for-it"]
+	path = wait-for-it
+	url = https://github.com/vishnubob/wait-for-it.git


### PR DESCRIPTION
Issue:  ` No url found for submodule path 'IdraPortal/wait-for-it' in .gitmodules`

```console
git clone git@github.com:jason-fox/Idra.git
Cloning into 'Idra'...
remote: Enumerating objects: 5335, done.
remote: Counting objects: 100% (1532/1532), done.
remote: Compressing objects: 100% (337/337), done.
remote: Total 5335 (delta 1258), reused 1241 (delta 1132), pack-reused 3803 (from 1)
Receiving objects: 100% (5335/5335), 26.86 MiB | 9.02 MiB/s, done.
Resolving deltas: 100% (3023/3023), done.
```

```console
cd Idra
git submodule update --init --recursive
Submodule 'IdraPortal-ngx' (https://github.com/OPSILab/IdraPortal-ngx) registered for path 'IdraPortal-ngx'
Submodule 'IdraPortal-ngx-Translations' (https://github.com/OPSILab/IdraPortal-ngx-Translations) registered for path 'IdraPortal-ngx-Translations'
fatal: No url found for submodule path 'IdraPortal/wait-for-it' in .gitmodules
```


Fix - remove directory and re-add missing submodule

```console
git rm wait-for-it
fatal: pathspec 'wait-for-it' did not match any files
git submodule add https://github.com/vishnubob/wait-for-it.git
Cloning into '/Users/jasonfox/Workspace/Idra/wait-for-it'...
remote: Enumerating objects: 147, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (4/4), done.
Receiving objects:  74% (109remote: Total 147 (delta 2), reused 0 (delta 0), pack-reused 143 (from 2)
Receiving objects: 100% (147/147), 30.70 KiB | 1.92 MiB/s, done.
Resolving deltas: 100% (58/58), done.
```